### PR TITLE
Allow using booleans in the generated graphql schema 

### DIFF
--- a/Apollo/JSONStandardTypeConversions.swift
+++ b/Apollo/JSONStandardTypeConversions.swift
@@ -93,8 +93,6 @@ extension Optional where Wrapped: JSONDecodable {
   }
 }
 
-
-
 extension RawRepresentable where RawValue: JSONDecodable {
   public init(jsonValue value: JSONValue) throws {
     let rawValue = try RawValue(jsonValue: value)

--- a/Apollo/JSONStandardTypeConversions.swift
+++ b/Apollo/JSONStandardTypeConversions.swift
@@ -70,6 +70,19 @@ extension Double: JSONDecodable, JSONEncodable {
   }
 }
 
+extension Bool: JSONDecodable, JSONEncodable {
+    public init(jsonValue value: JSONValue) throws {
+        guard let bool = value as? Bool else {
+            throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
+        }
+        self = bool
+    }
+    
+    public var jsonValue: JSONValue {
+        return self
+    }
+}
+
 extension Optional where Wrapped: JSONDecodable {
   public init(jsonValue value: JSONValue) throws {
     if value is NSNull {
@@ -79,6 +92,8 @@ extension Optional where Wrapped: JSONDecodable {
     }
   }
 }
+
+
 
 extension RawRepresentable where RawValue: JSONDecodable {
   public init(jsonValue value: JSONValue) throws {


### PR DESCRIPTION
using booleans currently leads to compile time errors, because they cant be converted into swifts types