### PR TITLE
add cancelling to apollo requests

### DIFF
--- a/Sources/ApolloClient.swift
+++ b/Sources/ApolloClient.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+public protocol Cancellable {
+    func cancel()
+}
+
 public class ApolloClient {
   let networkTransport: NetworkTransport
 
@@ -11,16 +15,16 @@ public class ApolloClient {
     self.init(networkTransport: HTTPNetworkTransport(url: url))
   }
 
-  public func fetch<Query: GraphQLQuery>(query: Query, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping GraphQLOperationResponseHandler<Query>) {
-    networkTransport.send(operation: query) { (result, error) in
+  public func fetch<Query: GraphQLQuery>(query: Query, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping GraphQLOperationResponseHandler<Query>) -> Cancellable {
+    return networkTransport.send(operation: query) { (result, error) in
       queue.async {
         completionHandler(result, error)
       }
     }
   }
 
-  public func perform<Mutation: GraphQLMutation>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping GraphQLOperationResponseHandler<Mutation>) {
-    networkTransport.send(operation: mutation) { (result, error) in
+  public func perform<Mutation: GraphQLMutation>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping GraphQLOperationResponseHandler<Mutation>) -> Cancellable {
+    return networkTransport.send(operation: mutation) { (result, error) in
       queue.async {
         completionHandler(result, error)
       }

--- a/Sources/NetworkTransport.swift
+++ b/Sources/NetworkTransport.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 public protocol NetworkTransport {
-  func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping GraphQLOperationResponseHandler<Operation>)
+  func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping GraphQLOperationResponseHandler<Operation>) -> Cancellable
 }
+
+extension URLSessionTask : Cancellable { }
 
 struct GraphQLResponseError: Error, LocalizedError {
   enum ErrorKind {
@@ -50,7 +52,7 @@ public class HTTPNetworkTransport: NetworkTransport {
     self.session = URLSession(configuration: configuration)
   }
 
-  public func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping GraphQLOperationResponseHandler<Operation>) {
+  public func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping GraphQLOperationResponseHandler<Operation>) -> Cancellable {
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
 
@@ -88,6 +90,7 @@ public class HTTPNetworkTransport: NetworkTransport {
       }
     }
     task.resume()
+    return task
   }
 
   private func parseResult<Data: GraphQLMapDecodable>(responseMap: GraphQLMap) throws -> GraphQLResult<Data> {


### PR DESCRIPTION
In the current implementation, both the `fetch` and `perform` operations of `ApolloClient` return a `Void` type. However, it's important, especially in fetching data, to be able to cancel an outbound request/response if, for instance, the user leaves the screen, or any other number of reasons.