### PR TITLE
Add additional debugging info when JSON decoding fails

### DIFF
--- a/Tests/ApolloTests/GraphQLMapDecodingTests.swift
+++ b/Tests/ApolloTests/GraphQLMapDecodingTests.swift
@@ -43,7 +43,8 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: [:])
 
     XCTAssertThrowsError(try with(returnType: String.self, map.value(forKey: "name"))) { (error) in
-      if case JSONDecodingError.missingValue(let key) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.missingValue(let key) = error.jsonDecodingError {
         XCTAssertEqual(key, "name")
       } else {
         XCTFail("Unexpected error: \(error)")
@@ -55,7 +56,8 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: ["name": NSNull()])
 
     XCTAssertThrowsError(try with(returnType: String.self, map.value(forKey: "name"))) { (error) in
-      if case JSONDecodingError.couldNotConvert(let value, let expectedType) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.jsonDecodingError {
         XCTAssertEqual(value as? NSNull, NSNull())
         XCTAssertTrue(expectedType == String.self)
       } else {
@@ -68,7 +70,8 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: ["name": 10])
 
     XCTAssertThrowsError(try with(returnType: String.self, map.value(forKey: "name"))) { (error) in
-      if case JSONDecodingError.couldNotConvert(let value, let expectedType) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.jsonDecodingError {
         XCTAssertEqual(value as? Int, 10)
         XCTAssertTrue(expectedType == String.self)
       } else {
@@ -99,7 +102,8 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: ["name": 10])
 
     XCTAssertThrowsError(try with(returnType: Optional<String>.self, map.optionalValue(forKey: "name"))) { (error) in
-      if case JSONDecodingError.couldNotConvert(let value, let expectedType) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.jsonDecodingError {
         XCTAssertEqual(value as? Int, 10)
         XCTAssertTrue(expectedType == String.self)
       } else {
@@ -118,7 +122,8 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: [:])
 
     XCTAssertThrowsError(try with(returnType: Array<Episode>.self, map.list(forKey: "appearsIn"))) { (error) in
-      if case JSONDecodingError.missingValue(let key) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.missingValue(let key) = error.jsonDecodingError {
         XCTAssertEqual(key, "appearsIn")
       } else {
         XCTFail("Unexpected error: \(error)")
@@ -130,7 +135,8 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: ["appearsIn": NSNull()])
 
     XCTAssertThrowsError(try with(returnType: Array<Episode>.self, map.list(forKey: "appearsIn"))) { (error) in
-      if case JSONDecodingError.couldNotConvert(let value, _) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert(let value, _) = error.jsonDecodingError {
         XCTAssertEqual(value as? NSNull, NSNull())
       } else {
         XCTFail("Unexpected error: \(error)")
@@ -142,9 +148,11 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: ["appearsIn": [4, 5, 6]])
 
     XCTAssertThrowsError(try with(returnType: Array<Episode>.self, map.list(forKey: "appearsIn"))) { (error) in
-      guard case JSONDecodingError.couldNotConvert = error else {
-        XCTFail("Unexpected error: \(error)")
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert = error.jsonDecodingError {
         return
+      } else {
+        XCTFail("Unexpected error: \(error)")
       }
     }
   }
@@ -171,9 +179,11 @@ class GraphQLMapDecodingTests: XCTestCase {
     let map = GraphQLMap(jsonObject: ["appearsIn": [4, 5, 6]])
 
     XCTAssertThrowsError(try with(returnType: Optional<Array<Episode>>.self, map.list(forKey: "appearsIn"))) { (error) in
-      guard case JSONDecodingError.couldNotConvert = error else {
-        XCTFail("Unexpected error: \(error)")
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert = error.jsonDecodingError {
         return
+      } else {
+        XCTFail("Unexpected error: \(error)")
       }
     }
   }

--- a/Tests/ApolloTests/ParseQueryResultDataTests.swift
+++ b/Tests/ApolloTests/ParseQueryResultDataTests.swift
@@ -39,7 +39,8 @@ class ParseQueryResultDataTests: XCTestCase {
     let query = HeroNameQuery()
 
     XCTAssertThrowsError(try query.parse(data: data)) { error in
-      if case JSONDecodingError.missingValue(let key) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.missingValue(let key) = error.jsonDecodingError {
         XCTAssertEqual(key, "name")
       } else {
         XCTFail("Unexpected error: \(error)")
@@ -53,7 +54,8 @@ class ParseQueryResultDataTests: XCTestCase {
     let query = HeroNameQuery()
 
     XCTAssertThrowsError(try query.parse(data: data)) { error in
-      if case JSONDecodingError.couldNotConvert(let value, let expectedType) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.jsonDecodingError {
         XCTAssertEqual(value as? Int, 10)
         XCTAssertTrue(expectedType == String.self)
       } else {
@@ -145,7 +147,8 @@ class ParseQueryResultDataTests: XCTestCase {
     let query = HeroDetailsQuery(episode: .empire)
 
     XCTAssertThrowsError(try query.parse(data: data)) { error in
-      if case JSONDecodingError.missingValue(let key) = error {
+      if let error = error as? GraphQLMapDecodingError,
+         case JSONDecodingError.missingValue(let key) = error.jsonDecodingError {
         XCTAssertEqual(key, "__typename")
       } else {
         XCTFail("Unexpected error: \(error)")


### PR DESCRIPTION
This commit takes a stab at implementing https://github.com/apollostack/apollo-ios/issues/20.

`GraphQLMap` now returns a `GraphQLMapDecodingError` instead of a `JSONDecodingError` which contains a little bit more information on where the decoding failed.

The new information can be accessed via the `key` and `localizedJson` properties in the error and will allow debugging to be a bit more descriptive.