### PR TITLE
Make GraphQLError.message publicly accessible

### DIFF
--- a/Sources/GraphQL.swift
+++ b/Sources/GraphQL.swift
@@ -29,7 +29,7 @@ public struct GraphQLResult<Data> {
 }
 
 public struct GraphQLError: Error {
-  let message: String
+  public let message: String
 }
 
 extension GraphQLError: GraphQLMappable {


### PR DESCRIPTION
@martijnwalraven - I assume this would need to be public in order to access the message returned inside the GraphQLError?