### PR TITLE
Make GraphQL response error type generic

### DIFF
--- a/Sources/ApolloClient.swift
+++ b/Sources/ApolloClient.swift
@@ -15,16 +15,16 @@ public class ApolloClient {
     self.init(networkTransport: HTTPNetworkTransport(url: url))
   }
 
-  @discardableResult public func fetch<Query: GraphQLQuery>(query: Query, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping (GraphQLResult<Query.Data>?, Error?) -> Void) -> Cancellable {
+  @discardableResult public func fetch<Query: GraphQLQuery, GraphQLErrorType: GraphQLMappable>(query: Query, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping (GraphQLResult<Query.Data, GraphQLErrorType>?, Error?) -> Void) -> Cancellable {
     return perform(operation: query, completionHandler: completionHandler)
   }
   
-  @discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping (GraphQLResult<Mutation.Data>?, Error?) -> Void) -> Cancellable {
+  @discardableResult public func perform<Mutation: GraphQLMutation, GraphQLErrorType: GraphQLMappable>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping (GraphQLResult<Mutation.Data, GraphQLErrorType>?, Error?) -> Void) -> Cancellable {
     return perform(operation: mutation, completionHandler: completionHandler)
   }
 
-  private func perform<Operation: GraphQLOperation>(operation: Operation, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping (GraphQLResult<Operation.Data>?, Error?) -> Void) -> Cancellable {
-    return networkTransport.send(operation: operation) { (response, error) in
+  private func perform<Operation: GraphQLOperation, GraphQLErrorType: GraphQLMappable>(operation: Operation, queue: DispatchQueue = DispatchQueue.main, completionHandler: @escaping (GraphQLResult<Operation.Data, GraphQLErrorType>?, Error?) -> Void) -> Cancellable {
+    return networkTransport.send(operation: operation) { (response: GraphQLResponse<Operation, GraphQLErrorType>?, error: Error?) in
       guard let response = response else {
         queue.async {
           completionHandler(nil, error)

--- a/Sources/GraphQL.swift
+++ b/Sources/GraphQL.swift
@@ -18,11 +18,11 @@ public protocol GraphQLMappable {
   init(reader: GraphQLResultReader) throws
 }
 
-public struct GraphQLResult<Data> {
+public struct GraphQLResult<Data, GraphQLErrorType> {
   public let data: Data?
-  public let errors: [GraphQLError]?
+  public let errors: [GraphQLErrorType]?
   
-  init(data: Data?, errors: [GraphQLError]?) {
+  init(data: Data?, errors: [GraphQLErrorType]?) {
     self.data = data
     self.errors = errors
   }

--- a/Sources/GraphQLResponse.swift
+++ b/Sources/GraphQLResponse.swift
@@ -1,4 +1,4 @@
-public final class GraphQLResponse<Operation: GraphQLOperation> {
+public final class GraphQLResponse<Operation: GraphQLOperation, GraphQLErrorType> where GraphQLErrorType: GraphQLMappable {
   let operation: Operation
   let rootObject: JSONObject
   
@@ -7,13 +7,13 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
     self.rootObject = rootObject
   }
   
-  public func parseResult() throws -> GraphQLResult<Operation.Data> {
+  public func parseResult() throws -> GraphQLResult<Operation.Data, GraphQLErrorType> {
     let reader = GraphQLResultReader { field, object, info in
       return (object ?? self.rootObject)[field.responseName]
     }
     
     let data: Operation.Data? = try reader.parse(object: rootObject["data"])
-    let errors: [GraphQLError]? = try reader.parse(array: rootObject["errors"])
+    let errors: [GraphQLErrorType]? = try reader.parse(array: rootObject["errors"])
     
     return GraphQLResult(data: data, errors: errors)
   }


### PR DESCRIPTION
This is a proof of concept to support extra GraphQL error keys, as mentioned in  #39 . I plan to test and refine this over the coming days in my application.

The type parameter name `GraphQLErrorType` seems suboptimal, but given the `GraphQLError` was already taken by a concrete type, it seemed like the least worst option 😛 . Here are some others:

* [POSSIBLE] Rename struct `GraphQLError` (perhaps `GraphQLConcreteError` or similar) and use `GraphQLError` as the type parameter name
* [NOT POSSIBLE] Use `ErrorType` as the type parameter name. The compiler gives you "ErrorType has been renamed to Error" warnings.

I wanted to get feedback before investing the time to update the unit tests.